### PR TITLE
#5238: kafka message header attributes

### DIFF
--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaHeadersAttributesExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaHeadersAttributesExtractor.java
@@ -16,34 +16,30 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
 
 /**
- * Extracts the specified "captured headers" (see KafkaMessageCapturedHeadersUtil) from a
- * REQUEST message.
+ * Extracts the specified "captured headers" (see KafkaMessageCapturedHeadersUtil) from a REQUEST
+ * message.
  *
- * This class is internal and is hence not for public use. Its APIs are unstable and can change at
- * any time.
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
  */
 public final class KafkaHeadersAttributesExtractor<REQUEST>
     implements AttributesExtractor<REQUEST, Void> {
 
-  /**
-   * List of header names to capture as attributes.
-   */
+  /** List of header names to capture as attributes. */
   private final List<String> capturedMessageHeaders;
-  /**
-   * Lens to get the Headers collection from a kafka message.
-   */
+  /** Lens to get the Headers collection from a kafka message. */
   private final Function<REQUEST, Headers> messageHeadersGetter;
+
   private final KafkaHeadersGetter kafkaHeadersGetter = new KafkaHeadersGetter();
 
-  public static final Function<? super ConsumerRecord<?, ?>, Headers> CONSUMER_RECORD_HEADERS_GETTER =
-      ConsumerRecord::headers;
+  public static final Function<? super ConsumerRecord<?, ?>, Headers>
+      CONSUMER_RECORD_HEADERS_GETTER = ConsumerRecord::headers;
 
-  public static final Function<? super ProducerRecord<?, ?>, Headers> PRODUCER_RECORD_HEADERS_GETTER =
-      ProducerRecord::headers;
+  public static final Function<? super ProducerRecord<?, ?>, Headers>
+      PRODUCER_RECORD_HEADERS_GETTER = ProducerRecord::headers;
 
   public KafkaHeadersAttributesExtractor(
-      List<String> capturedMessageHeaders,
-      Function<REQUEST, Headers> headersGetter) {
+      List<String> capturedMessageHeaders, Function<REQUEST, Headers> headersGetter) {
     this.capturedMessageHeaders = capturedMessageHeaders;
     this.messageHeadersGetter = headersGetter;
   }
@@ -51,7 +47,7 @@ public final class KafkaHeadersAttributesExtractor<REQUEST>
   @Override
   public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST message) {
     Headers headers = this.messageHeadersGetter.apply(message);
-    for (String headerName: capturedMessageHeaders) {
+    for (String headerName : capturedMessageHeaders) {
       String value = this.kafkaHeadersGetter.get(headers, headerName);
       if (value != null) {
         attributes.put(headerName, value);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaHeadersAttributesExtractor.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaHeadersAttributesExtractor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.kafka.internal;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class KafkaHeadersAttributesExtractor<REQUEST>
+    implements AttributesExtractor<REQUEST, Void> {
+
+  public abstract static class KafkaMessageHeadersGetter<REQUEST> {
+    public abstract Headers get(REQUEST message);
+  }
+
+  public static final KafkaMessageHeadersGetter<? super ConsumerRecord<?, ?>> CONSUMER_RECORD_HEADERS_GETTER =
+      new KafkaMessageHeadersGetter<ConsumerRecord<?, ?>>() {
+        @Override
+        public Headers get(ConsumerRecord<?, ?> message) {
+          return message.headers();
+        }
+      };
+
+  public static final KafkaMessageHeadersGetter<? super ProducerRecord<?, ?>> PRODUCER_RECORD_HEADERS_GETTER =
+      new KafkaMessageHeadersGetter<ProducerRecord<?, ?>>() {
+        @Override
+        public Headers get(ProducerRecord<?, ?> message) {
+          return message.headers();
+        }
+      };
+
+  private final List<String> capturedMessageHeaders;
+  private final KafkaMessageHeadersGetter<REQUEST> messageHeaderGetter;
+  private final KafkaHeadersGetter kafkaHeadersGetter = new KafkaHeadersGetter();
+
+  public KafkaHeadersAttributesExtractor(List<String> capturedMessageHeaders,
+      KafkaMessageHeadersGetter<REQUEST> headersGetter) {
+    this.capturedMessageHeaders = capturedMessageHeaders;
+    this.messageHeaderGetter = headersGetter;
+  }
+
+  @Override
+  public void onStart(AttributesBuilder attributes, Context parentContext, REQUEST message) {
+    Headers headers = this.messageHeaderGetter.get(message);
+    for (String headerName: capturedMessageHeaders) {
+      String value = this.kafkaHeadersGetter.get(headers, headerName);
+      if (value != null) {
+        attributes.put(headerName, value);
+      }
+    }
+  }
+
+  @Override
+  public void onEnd(
+      AttributesBuilder attributes,
+      Context context,
+      REQUEST message,
+      @Nullable Void unused,
+      @Nullable Throwable error) {}
+}

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
@@ -31,10 +31,6 @@ public final class KafkaInstrumenterFactory {
   private final OpenTelemetry openTelemetry;
   private final String instrumentationName;
   private ErrorCauseExtractor errorCauseExtractor = ErrorCauseExtractor.jdk();
-  private final List<String> capturedConsumerMessageHeaders =
-      KafkaMessageCapturedHeadersUtil.consumerMessageHeaders;
-  private final List<String> capturedProducerMessageHeaders =
-      KafkaMessageCapturedHeadersUtil.producerMessageHeaders;
 
   public KafkaInstrumenterFactory(OpenTelemetry openTelemetry, String instrumentationName) {
     this.openTelemetry = openTelemetry;
@@ -65,11 +61,11 @@ public final class KafkaInstrumenterFactory {
         .addAttributesExtractors(extractors)
         .addAttributesExtractor(new KafkaProducerAdditionalAttributesExtractor())
         .setErrorCauseExtractor(errorCauseExtractor);
-    if (!capturedProducerMessageHeaders.isEmpty()) {
+    if (KafkaMessageCapturedHeadersUtil.shouldCaptureProducerMessageHeaders()) {
       instrumenterBuilder
           .addAttributesExtractor(
               new KafkaHeadersAttributesExtractor<>(
-                  capturedProducerMessageHeaders,
+                  KafkaMessageCapturedHeadersUtil.getProducerMessageHeaders(),
                   KafkaHeadersAttributesExtractor.PRODUCER_RECORD_HEADERS_GETTER
               ));
     }
@@ -112,11 +108,11 @@ public final class KafkaInstrumenterFactory {
     if (KafkaConsumerExperimentalAttributesExtractor.isEnabled()) {
       builder.addAttributesExtractor(new KafkaConsumerExperimentalAttributesExtractor());
     }
-    if (!capturedConsumerMessageHeaders.isEmpty()) {
+    if (KafkaMessageCapturedHeadersUtil.shouldCaptureConsumerMessageHeaders()) {
       builder
           .addAttributesExtractor(
               new KafkaHeadersAttributesExtractor<>(
-                  capturedConsumerMessageHeaders,
+                  KafkaMessageCapturedHeadersUtil.getConsumerMessageHeaders(),
                   KafkaHeadersAttributesExtractor.CONSUMER_RECORD_HEADERS_GETTER
               ));
     }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaInstrumenterFactory.java
@@ -17,7 +17,6 @@ import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessageOperat
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.messaging.MessagingSpanNameExtractor;
 import java.util.Collections;
-import java.util.List;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -52,22 +51,20 @@ public final class KafkaInstrumenterFactory {
     KafkaProducerAttributesGetter getter = KafkaProducerAttributesGetter.INSTANCE;
     MessageOperation operation = MessageOperation.SEND;
 
-    InstrumenterBuilder<ProducerRecord<?, ?>, Void> instrumenterBuilder = Instrumenter
-        .<ProducerRecord<?, ?>, Void>builder(
-            openTelemetry,
-            instrumentationName,
-            MessagingSpanNameExtractor.create(getter, operation))
-        .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
-        .addAttributesExtractors(extractors)
-        .addAttributesExtractor(new KafkaProducerAdditionalAttributesExtractor())
-        .setErrorCauseExtractor(errorCauseExtractor);
+    InstrumenterBuilder<ProducerRecord<?, ?>, Void> instrumenterBuilder =
+        Instrumenter.<ProducerRecord<?, ?>, Void>builder(
+                openTelemetry,
+                instrumentationName,
+                MessagingSpanNameExtractor.create(getter, operation))
+            .addAttributesExtractor(MessagingAttributesExtractor.create(getter, operation))
+            .addAttributesExtractors(extractors)
+            .addAttributesExtractor(new KafkaProducerAdditionalAttributesExtractor())
+            .setErrorCauseExtractor(errorCauseExtractor);
     if (KafkaMessageCapturedHeadersUtil.shouldCaptureProducerMessageHeaders()) {
-      instrumenterBuilder
-          .addAttributesExtractor(
-              new KafkaHeadersAttributesExtractor<>(
-                  KafkaMessageCapturedHeadersUtil.getProducerMessageHeaders(),
-                  KafkaHeadersAttributesExtractor.PRODUCER_RECORD_HEADERS_GETTER
-              ));
+      instrumenterBuilder.addAttributesExtractor(
+          new KafkaHeadersAttributesExtractor<>(
+              KafkaMessageCapturedHeadersUtil.getProducerMessageHeaders(),
+              KafkaHeadersAttributesExtractor.PRODUCER_RECORD_HEADERS_GETTER));
     }
     return instrumenterBuilder.newInstrumenter(SpanKindExtractor.alwaysProducer());
   }
@@ -109,12 +106,10 @@ public final class KafkaInstrumenterFactory {
       builder.addAttributesExtractor(new KafkaConsumerExperimentalAttributesExtractor());
     }
     if (KafkaMessageCapturedHeadersUtil.shouldCaptureConsumerMessageHeaders()) {
-      builder
-          .addAttributesExtractor(
-              new KafkaHeadersAttributesExtractor<>(
-                  KafkaMessageCapturedHeadersUtil.getConsumerMessageHeaders(),
-                  KafkaHeadersAttributesExtractor.CONSUMER_RECORD_HEADERS_GETTER
-              ));
+      builder.addAttributesExtractor(
+          new KafkaHeadersAttributesExtractor<>(
+              KafkaMessageCapturedHeadersUtil.getConsumerMessageHeaders(),
+              KafkaHeadersAttributesExtractor.CONSUMER_RECORD_HEADERS_GETTER));
     }
 
     if (!KafkaPropagation.isPropagationEnabled()) {

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaMessageCapturedHeadersUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaMessageCapturedHeadersUtil.java
@@ -11,6 +11,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
 public class KafkaMessageCapturedHeadersUtil {
   private static final String CONSUMER_HEADERS_PROPERTY =
       "otel.instrumentation.kafka.capture-headers.consumer";
@@ -27,8 +31,8 @@ public class KafkaMessageCapturedHeadersUtil {
   }
 
   // these are naturally bounded because they only store keys listed in
-  // otel.instrumentation.http.capture-headers.server.request and
-  // otel.instrumentation.http.capture-headers.server.response
+  // otel.instrumentation.kafka.capture-headers.consumer and
+  // otel.instrumentation.kafka.capture-headers.producer
   private static final ConcurrentMap<String, AttributeKey<String>> consumerKeysCache =
       new ConcurrentHashMap<>();
   private static final ConcurrentMap<String, AttributeKey<String>> producerKeysCache =
@@ -48,7 +52,6 @@ public class KafkaMessageCapturedHeadersUtil {
   }
 
   private static AttributeKey<String> createKey(String type, String headerName) {
-    // headerName is always lowercase, see CapturedHttpHeaders
     String headerNormalized = headerName.replace('-', '_').replace(" ", "_");
     String key = "kafka." + type + ".header." + headerNormalized;
     return AttributeKey.stringKey(key);

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaMessageCapturedHeadersUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaMessageCapturedHeadersUtil.java
@@ -21,8 +21,8 @@ public class KafkaMessageCapturedHeadersUtil {
   private static final String PRODUCER_HEADERS_PROPERTY =
       "otel.instrumentation.kafka.capture-headers.producer";
 
-  static final List<String> consumerMessageHeaders;
-  static final List<String> producerMessageHeaders;
+  private static final List<String> consumerMessageHeaders;
+  private static final List<String> producerMessageHeaders;
 
   static {
     Config config = Config.get();
@@ -58,4 +58,20 @@ public class KafkaMessageCapturedHeadersUtil {
   }
 
   private KafkaMessageCapturedHeadersUtil() {}
+
+  public static List<String> getProducerMessageHeaders() {
+    return producerMessageHeaders;
+  }
+
+  public static boolean shouldCaptureProducerMessageHeaders() {
+    return !getProducerMessageHeaders().isEmpty();
+  }
+
+  public static List<String> getConsumerMessageHeaders() {
+    return consumerMessageHeaders;
+  }
+
+  public static boolean shouldCaptureConsumerMessageHeaders() {
+    return !getConsumerMessageHeaders().isEmpty();
+  }
 }

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaMessageCapturedHeadersUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaMessageCapturedHeadersUtil.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.kafka.internal;
 
 import static java.util.Collections.emptyList;

--- a/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaMessageCapturedHeadersUtil.java
+++ b/instrumentation/kafka/kafka-clients/kafka-clients-common/library/src/main/java/io/opentelemetry/instrumentation/kafka/internal/KafkaMessageCapturedHeadersUtil.java
@@ -1,0 +1,58 @@
+package io.opentelemetry.instrumentation.kafka.internal;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.instrumentation.api.config.Config;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+public class KafkaMessageCapturedHeadersUtil {
+  private static final String CONSUMER_HEADERS_PROPERTY =
+      "otel.instrumentation.kafka.capture-headers.consumer";
+  private static final String PRODUCER_HEADERS_PROPERTY =
+      "otel.instrumentation.kafka.capture-headers.producer";
+
+  static final List<String> consumerMessageHeaders;
+  static final List<String> producerMessageHeaders;
+
+  static {
+    Config config = Config.get();
+    consumerMessageHeaders = config.getList(CONSUMER_HEADERS_PROPERTY, emptyList());
+    producerMessageHeaders = config.getList(PRODUCER_HEADERS_PROPERTY, emptyList());
+  }
+
+  // these are naturally bounded because they only store keys listed in
+  // otel.instrumentation.http.capture-headers.server.request and
+  // otel.instrumentation.http.capture-headers.server.response
+  private static final ConcurrentMap<String, AttributeKey<String>> consumerKeysCache =
+      new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, AttributeKey<String>> producerKeysCache =
+      new ConcurrentHashMap<>();
+
+  static List<String> lowercase(List<String> names) {
+    return unmodifiableList(
+        names.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.toList()));
+  }
+
+  static AttributeKey<String> requestAttributeKey(String headerName) {
+    return consumerKeysCache.computeIfAbsent(headerName, n -> createKey("consumer", n));
+  }
+
+  static AttributeKey<String> responseAttributeKey(String headerName) {
+    return producerKeysCache.computeIfAbsent(headerName, n -> createKey("producer", n));
+  }
+
+  private static AttributeKey<String> createKey(String type, String headerName) {
+    // headerName is always lowercase, see CapturedHttpHeaders
+    String headerNormalized = headerName.replace('-', '_').replace(" ", "_");
+    String key = "kafka." + type + ".header." + headerNormalized;
+    return AttributeKey.stringKey(key);
+  }
+
+  private KafkaMessageCapturedHeadersUtil() {}
+}


### PR DESCRIPTION
- `KafkaMessageCapturedHeadersUtil`: map configuration properties to arrays
- `KafkaHeadersAttributesExtractor`: an AttributesExtractor that adds a list of captured headers as attributes
- `KafkaInstrumenterFactory`
  - checks the "captured headers" in `KafkaMessageCapturedHeadersUtil`, for producer or consumer 
  - if headers are captured, it adds a `KafkaHeadersAttributesExtractor` instance to the attributes extractor list (`addAttributesExtractor`)